### PR TITLE
Replace Action trait objects with enum dispatch pattern

### DIFF
--- a/dicom-anonymization/src/actions/empty.rs
+++ b/dicom-anonymization/src/actions/empty.rs
@@ -5,7 +5,7 @@ use dicom_object::DefaultDicomObject;
 use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 /// Action that empties DICOM element values while preserving the element structure.
@@ -15,7 +15,7 @@ use crate::config::Config;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Empty;
 
-impl DataElementAction for Empty {
+impl ProcessElement for Empty {
     fn process<'a>(
         &'a self,
         _config: &Config,

--- a/dicom-anonymization/src/actions/hash.rs
+++ b/dicom-anonymization/src/actions/hash.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::actions::errors::ActionError;
 use crate::actions::utils::{is_empty_element, truncate_to};
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::{Config, ConfigError};
 use crate::dicom;
 use crate::hasher::HashFn;
@@ -104,7 +104,7 @@ impl Default for Hash {
     }
 }
 
-impl DataElementAction for Hash {
+impl ProcessElement for Hash {
     fn process<'a>(
         &'a self,
         config: &Config,

--- a/dicom-anonymization/src/actions/hash_date.rs
+++ b/dicom-anonymization/src/actions/hash_date.rs
@@ -1,6 +1,6 @@
 use crate::actions::errors::ActionError;
 use crate::actions::utils::{is_empty_element, truncate_to};
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 use crate::hasher::HashFn;
 use crate::tags;
@@ -75,7 +75,7 @@ impl Default for HashDate {
     }
 }
 
-impl DataElementAction for HashDate {
+impl ProcessElement for HashDate {
     fn process<'a>(
         &'a self,
         config: &Config,

--- a/dicom-anonymization/src/actions/hash_uid.rs
+++ b/dicom-anonymization/src/actions/hash_uid.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
 use crate::actions::utils::{is_empty_element, truncate_to};
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::uid_root::UidRoot;
 use crate::config::Config;
 use crate::hasher::HashFn;
@@ -42,7 +42,7 @@ impl HashUID {
     }
 }
 
-impl DataElementAction for HashUID {
+impl ProcessElement for HashUID {
     fn process<'a>(
         &'a self,
         config: &Config,

--- a/dicom-anonymization/src/actions/keep.rs
+++ b/dicom-anonymization/src/actions/keep.rs
@@ -3,7 +3,7 @@ use dicom_object::DefaultDicomObject;
 use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 /// Action that preserves DICOM element values unchanged.
@@ -15,7 +15,7 @@ use crate::config::Config;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Keep;
 
-impl DataElementAction for Keep {
+impl ProcessElement for Keep {
     fn process<'a>(
         &'a self,
         _config: &Config,

--- a/dicom-anonymization/src/actions/mod.rs
+++ b/dicom-anonymization/src/actions/mod.rs
@@ -27,7 +27,7 @@ use replace::Replace;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 
-pub(crate) trait DataElementAction {
+pub(crate) trait ProcessElement {
     fn process<'a>(
         &'a self,
         config: &Config,
@@ -49,7 +49,7 @@ pub(crate) enum ActionProcessor {
     Replace(Replace),
 }
 
-impl DataElementAction for ActionProcessor {
+impl ProcessElement for ActionProcessor {
     fn process<'a>(
         &'a self,
         config: &Config,

--- a/dicom-anonymization/src/actions/mod.rs
+++ b/dicom-anonymization/src/actions/mod.rs
@@ -49,9 +49,8 @@ pub(crate) enum ActionProcessor {
     Replace(Replace),
 }
 
-impl ActionProcessor {
-    /// Process an element using the concrete action type
-    pub(crate) fn process<'a>(
+impl DataElementAction for ActionProcessor {
+    fn process<'a>(
         &'a self,
         config: &Config,
         obj: &DefaultDicomObject,

--- a/dicom-anonymization/src/actions/mod.rs
+++ b/dicom-anonymization/src/actions/mod.rs
@@ -36,6 +36,40 @@ pub(crate) trait DataElementAction {
     ) -> Result<Option<Cow<'a, InMemElement>>, ActionError>;
 }
 
+/// Concrete action processor that avoids heap allocation through enum dispatch
+#[derive(Debug, Clone)]
+pub(crate) enum ActionProcessor {
+    Empty(Empty),
+    Hash(Hash),
+    HashDate(HashDate),
+    HashUID(HashUID),
+    Keep(Keep),
+    None(NoAction),
+    Remove(Remove),
+    Replace(Replace),
+}
+
+impl ActionProcessor {
+    /// Process an element using the concrete action type
+    pub(crate) fn process<'a>(
+        &'a self,
+        config: &Config,
+        obj: &DefaultDicomObject,
+        elem: &'a InMemElement,
+    ) -> Result<Option<Cow<'a, InMemElement>>, ActionError> {
+        match self {
+            ActionProcessor::Empty(action) => action.process(config, obj, elem),
+            ActionProcessor::Hash(action) => action.process(config, obj, elem),
+            ActionProcessor::HashDate(action) => action.process(config, obj, elem),
+            ActionProcessor::HashUID(action) => action.process(config, obj, elem),
+            ActionProcessor::Keep(action) => action.process(config, obj, elem),
+            ActionProcessor::None(action) => action.process(config, obj, elem),
+            ActionProcessor::Remove(action) => action.process(config, obj, elem),
+            ActionProcessor::Replace(action) => action.process(config, obj, elem),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TagString(pub Tag);
 
@@ -104,19 +138,19 @@ pub enum Action {
 }
 
 impl Action {
-    pub(crate) fn get_action_struct(&self) -> Box<dyn DataElementAction> {
+    pub(crate) fn get_action_processor(&self) -> ActionProcessor {
         match self {
-            Action::Empty => Box::new(Empty),
+            Action::Empty => ActionProcessor::Empty(Empty),
             Action::Hash { length } => {
                 let hash_length = length.as_ref().map(|length| HashLength(*length));
-                Box::new(Hash::new(hash_length))
+                ActionProcessor::Hash(Hash::new(hash_length))
             }
-            Action::HashDate => Box::new(HashDate::default()),
-            Action::HashUID => Box::new(HashUID),
-            Action::Keep => Box::new(Keep),
-            Action::None => Box::new(NoAction),
-            Action::Remove => Box::new(Remove),
-            Action::Replace { value } => Box::new(Replace::new(value.clone())),
+            Action::HashDate => ActionProcessor::HashDate(HashDate::default()),
+            Action::HashUID => ActionProcessor::HashUID(HashUID),
+            Action::Keep => ActionProcessor::Keep(Keep),
+            Action::None => ActionProcessor::None(NoAction),
+            Action::Remove => ActionProcessor::Remove(Remove),
+            Action::Replace { value } => ActionProcessor::Replace(Replace::new(value.clone())),
         }
     }
 }

--- a/dicom-anonymization/src/actions/no_action.rs
+++ b/dicom-anonymization/src/actions/no_action.rs
@@ -3,7 +3,7 @@ use dicom_object::DefaultDicomObject;
 use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 /// Action that performs no operation on DICOM elements.
@@ -13,7 +13,7 @@ use crate::config::Config;
 #[derive(Debug, Clone, PartialEq)]
 pub struct NoAction;
 
-impl DataElementAction for NoAction {
+impl ProcessElement for NoAction {
     fn process<'a>(
         &'a self,
         _config: &Config,

--- a/dicom-anonymization/src/actions/remove.rs
+++ b/dicom-anonymization/src/actions/remove.rs
@@ -3,7 +3,7 @@ use dicom_object::DefaultDicomObject;
 use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 /// Action that completely removes DICOM elements from the dataset.
@@ -13,7 +13,7 @@ use crate::config::Config;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Remove;
 
-impl DataElementAction for Remove {
+impl ProcessElement for Remove {
     fn process<'a>(
         &'a self,
         _config: &Config,

--- a/dicom-anonymization/src/actions/replace.rs
+++ b/dicom-anonymization/src/actions/replace.rs
@@ -5,7 +5,7 @@ use dicom_object::DefaultDicomObject;
 use std::borrow::Cow;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 /// Action that replaces DICOM element values with a fixed replacement value.
@@ -24,7 +24,7 @@ impl Replace {
     }
 }
 
-impl DataElementAction for Replace {
+impl ProcessElement for Replace {
     fn process<'a>(
         &'a self,
         _config: &Config,

--- a/dicom-anonymization/src/processor.rs
+++ b/dicom-anonymization/src/processor.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 
 use crate::actions::errors::ActionError;
-use crate::actions::DataElementAction;
+use crate::actions::ProcessElement;
 use crate::config::Config;
 
 #[derive(Error, Debug, PartialEq)]

--- a/dicom-anonymization/src/processor.rs
+++ b/dicom-anonymization/src/processor.rs
@@ -150,8 +150,8 @@ impl Processor for DefaultProcessor {
         elem: &'a InMemElement,
     ) -> Result<Option<Cow<'a, InMemElement>>> {
         let action = self.config.get_action(&elem.tag());
-        let action_struct = action.get_action_struct();
-        let process_result = action_struct.process(&self.config, obj, elem);
+        let action_processor = action.get_action_processor();
+        let process_result = action_processor.process(&self.config, obj, elem);
 
         match process_result {
             Ok(None) => Ok(None),

--- a/dicom-anonymization/src/processor.rs
+++ b/dicom-anonymization/src/processor.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use thiserror::Error;
 
 use crate::actions::errors::ActionError;
+use crate::actions::DataElementAction;
 use crate::config::Config;
 
 #[derive(Error, Debug, PartialEq)]


### PR DESCRIPTION
Implement ActionProcessor enum to eliminate heap allocations from Box<dyn DataElementAction> usage. This change provides:

- Zero heap allocations per element processed
- Better cache performance through inline storage
- Compile-time dispatch optimization
- Improved memory locality

For DICOM files with thousands of elements, this eliminates thousands of heap allocations per file processed while maintaining complete API compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)